### PR TITLE
improved get-scheduledtask efficiency

### DIFF
--- a/1803/1803_VDI_Configuration.ps1
+++ b/1803/1803_VDI_Configuration.ps1
@@ -69,9 +69,10 @@ If (Test-Path .\SchTaskList.txt)
 }
 If ($SchTasksList.count -gt 0)
 {
+    $EnabledScheduledTasks = Get-ScheduledTask | Where-Object {$_.State -ne "Disabled"}
     Foreach ($Item in $SchTasksList)
     {
-        Get-ScheduledTask | Where-Object {$_.TaskName -like "$($Item.trim())"} | Disable-ScheduledTask
+        $EnabledScheduledTasks | Where-Object {$_.TaskName -like "$($Item.trim())"} | Disable-ScheduledTask
     }
 }
 #endregion

--- a/1903/Win10_1903_VDI_Optimize.ps1
+++ b/1903/Win10_1903_VDI_Optimize.ps1
@@ -79,10 +79,11 @@ If (Test-Path .\Win10_1903_SchTaskList.txt)
 }
 If ($SchTasksList.count -gt 0)
 {
+    $EnabledScheduledTasks = Get-ScheduledTask | Where-Object {$_.State -ne "Disabled"}
     Foreach ($Item in $SchTasksList)
     {
         $Task = (($Item -split ":")[0]).Trim()
-        Get-ScheduledTask | Where-Object { $_.TaskName -like "*$Task*" } | Disable-ScheduledTask
+        $EnabledScheduledTasks | Where-Object { $_.TaskName -like "*$Task*" } | Disable-ScheduledTask
     }
 }
 #endregion

--- a/1909/Win10_1909_VDI_Optimize.ps1
+++ b/1909/Win10_1909_VDI_Optimize.ps1
@@ -82,10 +82,11 @@ If (Test-Path .\Win10_1909_SchTaskList.txt)
 }
 If ($SchTasksList.count -gt 0)
 {
+    $EnabledScheduledTasks = Get-ScheduledTask | Where-Object {$_.State -ne "Disabled"}
     Foreach ($Item in $SchTasksList)
     {
         $Task = (($Item -split ":")[0]).Trim()
-        Get-ScheduledTask | Where-Object { $_.TaskName -like "*$Task*" } | Disable-ScheduledTask
+        $EnabledScheduledTasks | Where-Object { $_.TaskName -like "*$Task*" } | Disable-ScheduledTask
     }
 }
 #endregion


### PR DESCRIPTION
get-scheduledtasks was being called for every scheduled task we intended to disable.

this was taking over 10 minutes on my resource constrained gold master, calling get-scheduledtasks once (and filtering for is not disabled), storing in a variable, and using that instead changed that portion of the code to be a 9 minute runtime to 1 minute runtime.